### PR TITLE
Borrado de saltos de línea

### DIFF
--- a/script/Menu.py
+++ b/script/Menu.py
@@ -78,6 +78,8 @@ def LecturaTXT():
                 for line in route_file.readlines():
                     print('Ruta ', i, ':', line)
                     i+=1
+                    line = line.replace("\n", "")
+                    print(line)
                     route.append(line)
             break
         except FileNotFoundError:


### PR DESCRIPTION
Los saltos de línea producían un error a la hora de leer las rutas.